### PR TITLE
The filename option needs to be set to use the extends keyword

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = function(options){
 
   function jade(file, callback){
     var newFile = clone(file);
+    opts.filename = file.path;
     var compiled = compile(String(newFile.contents), opts);
     if(opts.client){
       newFile.path = ext(newFile.path, '.js');

--- a/test/extends.js
+++ b/test/extends.js
@@ -1,0 +1,28 @@
+var expect = require('chai').expect;
+var task = require('../');
+var path = require('path');
+var fs = require('fs');
+ 
+var filePath = path.join(__dirname, "fixtures", "extends.jade");
+var file = {
+  path: filePath,
+  shortened: 'extends.jade',
+  contents: fs.readFileSync(filePath)
+};
+
+describe('gulp-jade', function () {
+  "use strict";
+  describe('extends', function () {
+    it('should compile a jade template with an extends', function (done) {
+      var stream = task();
+      stream.on('error', done);
+      stream.on('data', function (newFile) {
+        expect(newFile).to.be.ok;
+        expect(newFile.contents).to.be.ok;
+        expect(newFile.contents.toString()).to.equal('<div><h1>Hello World</h1></div>');
+        done();
+      });
+      stream.write(file);
+    });
+  });
+});

--- a/test/fixtures/_layout.jade
+++ b/test/fixtures/_layout.jade
@@ -1,0 +1,2 @@
+div
+  block content

--- a/test/fixtures/extends.jade
+++ b/test/fixtures/extends.jade
@@ -1,0 +1,4 @@
+extend _layout
+
+block content
+  h1 Hello World

--- a/test/test.js
+++ b/test/test.js
@@ -21,6 +21,7 @@ describe('gulp-jade compilation', function(){
       options = options || {};
       var ext = options.client ? '.js' : '.html';
       return es.map(function(file){
+        options.filename = filename;
         var compiled = jade.compile(fs.readFileSync(filename), options);
         var expected = options.client ? compiled.toString() : compiled(options.data);
         expect(expected).to.equal(String(file.contents));


### PR DESCRIPTION
Jade was throwing an error because the filename option wasn't set when trying to use the extends keyword (for template inheritance)

```
stream.js:81
      throw er; // Unhandled stream error in pipe.
            ^
Error: the "filename" option is required to use "extends" with "relative" paths
    at Object.Parser.resolvePath (/home/vagrant/frontend/node_modules/gulp-jade/node_modules/jade/lib/parser.js:399:13)
    at Object.Parser.parseExtends (/home/vagrant/frontend/node_modules/gulp-jade/node_modules/jade/lib/parser.js:418:21)
    at Object.Parser.parseExpr (/home/vagrant/frontend/node_modules/gulp-jade/node_modules/jade/lib/parser.js:210:21)
    at Object.Parser.parse (/home/vagrant/frontend/node_modules/gulp-jade/node_modules/jade/lib/parser.js:133:25)
    at parse (/home/vagrant/frontend/node_modules/gulp-jade/node_modules/jade/lib/jade.js:93:62)
    at exports.compile (/home/vagrant/frontend/node_modules/gulp-jade/node_modules/jade/lib/jade.js:154:9)
    at jade (/home/vagrant/frontend/node_modules/gulp-jade/index.js:13:20)
    at Stream.module.exports.stream.write (/home/vagrant/frontend/node_modules/gulp-jade/node_modules/event-stream/node_modules/map-stream/index.js:57:28)
    at Stream.ondata (stream.js:38:26)
    at Stream.EventEmitter.emit (events.js:96:17)
    at next (/home/vagrant/gulp/node_modules/event-stream/node_modules/map-stream/index.js:45:25)
    at module.exports (/home/vagrant/gulp/lib/readFile.js:7:5)
    at fs.readFile (fs.js:176:14)
    at Object.oncomplete (fs.js:297:15)
```
