### PR TITLE
Update Jade to v1.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,18 +2,17 @@
 
 var es = require('event-stream');
 var compile = require('jade').compile;
+var compileClient = require('jade').compileClient;
 var ext = require('gulp-util').replaceExtension;
 var isStream = require('gulp-util').isStream;
 var isBuffer = require('gulp-util').isBuffer;
 
 function handleCompile(contents, opts){
-  var compiled = compile(contents, opts);
-
   if(opts.client){
-    return compiled.toString();
+    return compileClient(contents, opts).toString();
   }
 
-  return compiled(opts.data);
+  return compile(contents, opts)(opts.data);
 }
 
 function handleExtension(filepath, opts){

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Blaine Bublitz <blaine@iceddev.com>",
   "dependencies": {
     "event-stream": "~3.0.15",
-    "jade": "~0.35.0",
+    "jade": "~1.0.0",
     "gulp-util": "~2.1.1"
   },
   "main": "index.js",


### PR DESCRIPTION
I've updated the Jade dependency version in `package.json`.

Also, in Jade v1.0.0, the `client` option has been deprecated in favour of `jade.compileClient()`, so I've updated the plugin to reflect this.
