### PR TITLE
Don't double wrap jade template errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = function(options){
       try {
         file.contents = new Buffer(handleCompile(String(file.contents), opts));
       } catch(e) {
-        this.emit('error', new Error(e));
+        this.emit('error', e);
       }
     }
 


### PR DESCRIPTION
Makes debugging template errors much simpler. With
a double wrap, stacktrace will be truncated such
that it looks like something is wrong with
gulp-jade, when it's really just a simple typo in
your template.
