### PR TITLE
Ability to transform compiled client string

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,10 @@ var PluginError = require('gulp-util').PluginError;
 
 function handleCompile(contents, opts){
   if(opts.client){
-    return compileClient(contents, opts);
+    var client = compileClient(contents, opts);
+  	if (opts.transformer) client = opts.transformer(client, opts.filename);
+
+    return client;
   }
 
   return compile(contents, opts)(opts.locals || opts.data);


### PR DESCRIPTION
I was running into issues where vinyl-map didn't handle gulp.watch gracefully and would error out. I was doing custom manipulation after getting the strings from gulp-jade, so I added in the ability to transform the string directly in gulp-jade.
