### PR TITLE
added ability to accept its data from file.data

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,49 @@ gulp.task('templates', function() {
 });
 ```
 
+## Use with [gulp-data](https://www.npmjs.org/package/gulp-data)
+
+As an alternative, the ```gulp-data``` plugin, is a standard method for piping data down-stream to other plugins that need data in the form of a new file property ```file.data```. If you have data from a JSON file, front-matter, a database, or anything really, use ```gulp-data``` to pass that data to gulp-jade.
+
+Retrieve data from a JSON file, keyed on file name:
+
+```
+var getJsonData = function(file, cb) {
+  var jsonPath = './examples/' + path.basename(file.path) + '.json';
+  cb(require(jsonPath));
+};
+
+gulp.task('json-test', function() {
+  return gulp.src('./examples/test1.html')
+    .pipe(data(getJsonData))
+    .pipe(jade())
+    .pipe(gulp.dest('build'));
+});
+```
+
+Since gulp-data provides a callback, it means you can get data from a database query as well:
+
+```
+var getMongoData = function(file, cb) {
+  MongoClient.connect('mongodb://127.0.0.1:27017/gulp-data-test', function(err, db) {
+    var collection = db.collection('file-data-test');
+    collection.findOne({filename: path.basename(file.path)}, function(err, doc) {
+      db.close();
+      cb(doc);
+    });
+  });
+};
+
+gulp.task('db-test', function() {
+  return gulp.src('./examples/test3.html')
+    .pipe(data(getMongoData))
+    .pipe(jade())
+    .pipe(gulp.dest('build'));
+});
+````
+
+More info on [gulp-data](https://www.npmjs.org/package/gulp-data)
+
 ## LICENSE
 
 (MIT License)

--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ function handleExtension(filepath, opts){
   if(opts.client){
     return ext(filepath, '.js');
   }
-
   return ext(filepath, '.html');
 }
 
@@ -27,6 +26,11 @@ module.exports = function(options){
 
   function CompileJade(file, enc, cb){
     opts.filename = file.path;
+
+    if (file.data) {
+      opts.data = file.data;
+    }
+
     file.path = handleExtension(file.path, opts);
 
     if(file.isStream()){

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,18 @@ var extname = require('path').extname;
 
 var filename = path.join(__dirname, './fixtures/helloworld.jade');
 
+// Mock Data Plugin
+// (not testing the gulp-data plugin options, just that gulp-jade can get its data from file.data)
+var setData = function(){
+  return through.obj(function(file, enc, callback) {
+    file.data = {
+      title: 'Greetings!'
+    };
+    this.push(file);
+    return callback();
+  });
+};
+
 function expectStream(t, options){
   options = options || {};
   var ext = options.client ? '.js' : '.html';
@@ -62,6 +74,17 @@ test('should compile my jade files into HTML with data passed in', function(t){
     .pipe(expectStream(t, {
       data: {
         title: 'Yellow Curled'
+      }
+    }));
+});
+
+test('should compile my jade files into HTML with data property', function(t){
+  gulp.src(filename)
+    .pipe(setData())
+    .pipe(task())
+    .pipe(expectStream(t, {
+      data: {
+        title: 'Greetings!'
       }
     }));
 });


### PR DESCRIPTION
I've created a de-coupled (generic) data source plugin that sets a `data` attribute to the file object. The jade plugin remains agnostic to how that data object gets set, but it's a good proof of concept for how this can be standardized. The data attribute can be set from a variety of sources such a JSON file, front-matter, a database, anything really. See https://www.npmjs.org/package/gulp-data for more detail
