### PR TITLE
add opt.suffix to package client js into modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ module.exports = function(options){
     if(file.isBuffer()){
       try {
         file.contents = new Buffer(handleCompile(String(file.contents), opts));
+        opts.suffix && file.contents += opts.suffix;
       } catch(e) {
         return cb(new PluginError('gulp-jade', e));
       }

--- a/index.js
+++ b/index.js
@@ -40,7 +40,10 @@ module.exports = function(options){
     if(file.isBuffer()){
       try {
         file.contents = new Buffer(handleCompile(String(file.contents), opts));
-        opts.suffix && file.contents += opts.suffix;
+        if ( 'suffix' in opts) {
+          var append = new Buffer(opts.suffix, "binary");
+          file.contents = Buffer.concat([file.contents, append]);
+        }
       } catch(e) {
         return cb(new PluginError('gulp-jade', e));
       }


### PR DESCRIPTION
``` javascript
task({
    client:true,
    suffix:'\nexports.render=template;'
})
```

convert the clientJS to a CMD module

It's useful to me : )
