### PR TITLE
Enable access to jade instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var through = require('through2');
 var compile = require('jade').compile;
 var compileClient = require('jade').compileClient;
 var ext = require('gulp-util').replaceExtension;
+var jade = require('jade');
 var PluginError = require('gulp-util').PluginError;
 
 function handleCompile(contents, opts){
@@ -49,3 +50,5 @@ module.exports = function(options){
 
   return through.obj(CompileJade);
 };
+
+module.exports.jade = jade;


### PR DESCRIPTION
I wanted to be able to register custom filters for the jade compilation step, but didn't have access to `jade.filters`.

Now I can simply:

```
var jade = require( "gulp-jade" );
var filters = jade.jade.filters;
filters.something = function(input) {
    return "something";
};
```

Any other solution would be welcome as well.
