### PR TITLE
Exposing jade object. Desirable for defining filters.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 'use strict';
 
 var through = require('through2');
-var compile = require('jade').compile;
-var compileClient = require('jade').compileClient;
+var jade = require('jade');
+var compile = jade.compile;
+var compileClient = jade.compileClient;
 var ext = require('gulp-util').replaceExtension;
 var PluginError = require('gulp-util').PluginError;
 
@@ -21,7 +22,7 @@ function handleExtension(filepath, opts){
   return ext(filepath, '.html');
 }
 
-module.exports = function(options){
+function gulpJade(options){
   var opts = options || {};
 
   function CompileJade(file, enc, cb){
@@ -49,3 +50,6 @@ module.exports = function(options){
 
   return through.obj(CompileJade);
 };
+
+gulpJade.jade = jade;
+module.exports = gulpJade;


### PR DESCRIPTION
Hi. It would be nice to be able to define jade filters from gulpfiles. From what I've found it seems the way to do this is with something like `require('jade').filters.myFilter = function () { ... }`. So, to be able to define filters in `gulpfile.js` I would need to access that filters object, or just jade's main object.

I just added a reference to the jade object in your modules exports so it can be accessed with `require('gulp-jade').jade`. Please consider merging if you think this is desirable. Any reasons why this is not a good idea? Anyone know other way of defining filters?
