### PR TITLE
Added option to avoid that `gulp` process ends on a compilation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ gulp.task('jade', function () {
 })
 ```
 
+`logErrors` option, when is `true` then if a compilation error happens, it is only showed in the console, hence is not reported to `gulp` through a callback.
+It is useful because sometimes you don't want to return the error to avoid to break `gulp` process and only want to see it in the console, e.g. When you are developing and you want to `watch` changes on jade files but you don't want to abort the process if you write a incorrect `jade` syntax.
+
 ## AMD
 
 If you are trying to wrap your Jade template functions in an AMD wrapper, use [`gulp-wrap-amd`](https://github.com/phated/gulp-wrap-amd)

--- a/index.js
+++ b/index.js
@@ -50,7 +50,6 @@ module.exports = function(options){
       } catch(e) {
         if (opts.logErrors === true) {
           log('Jade error %s', e);
-          return cb();
         } else {
           return cb(new PluginError('gulp-jade', e));
         }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,12 @@
 'use strict';
 
+
 var jade = require('jade');
 var extend = require('xtend');
 var through = require('through2');
-var ext = require('gulp-util').replaceExtension;
+var gutil = require('gulp-util');
+var ext = gutil.replaceExtension;
+var log = gutil.log;
 var PluginError = require('gulp-util').PluginError;
 
 function handleCompile(contents, opts){
@@ -45,7 +48,12 @@ module.exports = function(options){
       try {
         file.contents = new Buffer(handleCompile(String(file.contents), opts));
       } catch(e) {
-        return cb(new PluginError('gulp-jade', e));
+        if (opts.logErrors === true) {
+          log('Jade error %s', e);
+          return cb();
+        } else {
+          return cb(new PluginError('gulp-jade', e));
+        }
       }
     }
     cb(null, file);

--- a/test/error.js
+++ b/test/error.js
@@ -5,6 +5,7 @@ var test = require('tap').test;
 var gulp = require('gulp');
 var task = require('../');
 var path = require('path');
+var through = require('through2');
 
 var filename = path.join(__dirname, './fixtures/jade-error.jade');
 
@@ -16,4 +17,17 @@ test('should emit errors of jade correctly', function(t){
         t.ok(err instanceof Error);
         t.end();
       }));
+});
+
+test('should not emit errors of jade correctly when `logErrors` option is `true`', function(t){
+  gulp.src(filename)
+  .pipe(task({
+    logErrors: true
+  })
+  .on('error', function (){
+    t.notOk(false, 'Error is not expected when `logErrors` is true');
+  }))
+  .pipe(through.obj(function (){
+    t.end();
+  }));
 });


### PR DESCRIPTION
I added a new option `logErrors` to change the behaviour when a compilation error happens. Right now if a compilation error happens then the plugin report the error to `gulp` calling the callback with it and `gulp` abort the process due this.

There are situations where you don't want that behaviour, you want to keep the process running and you only want to know that an error happened, for example if you are watching changes in jade files because you are developing, you don't want that a compilation error stop `gulp` watch process, you want to see the error to fix it and recompile again so keep `watch` process running, as I've also commented in the README.
