### PR TITLE
Adding filename support to client templates.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@ module.exports = function(options){
 
   function CompileJade(file, enc, cb){
     opts.filename = file.path;
+    if (opts.templateUseFilename)
+      opts.name = /(.*)(\..+)/.exec(file.relative)[1].toString();
 
     if(file.data){
       opts.data = file.data;


### PR DESCRIPTION
This allows the user the flexibility to use gulp-jade to compile client templates with unique names based on filename.

```
$.jade({
                pretty: opts.args.release ? false : true,
                compileDebug: false,
                client:true,
                templateUseFilename:true
            })
```

If the user wants to have unique functions defined by the jade files name. It also supports allowing the user to use name without 'templateUseFilename' to overwrite it as needed.
