### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,7 @@
   "scripts": {
     "test": "gulp jshint && tap ./test"
   },
-  "licenses": [
-    {
-      "type": "MIT"
-    }
-  ],
+  "license": "MIT",
   "devDependencies": {
     "gulp": "^3.8.10",
     "tap": "^0.5.0",


### PR DESCRIPTION
deprecated `licenses` from npm@2.10

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
