### PR TITLE
Update jade version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Blaine Bublitz <blaine@iceddev.com>",
   "dependencies": {
     "gulp-util": "^3.0.2",
-    "jade": "1.1 - 1.9",
+    "jade": "^1.1.0",
     "through2": "^0.6.3"
   },
   "files": [


### PR DESCRIPTION
Adding `^1.1.0` allows for support of new releases (`1.11.0` is the latest) as well as any release in between (down to `1.1.0`). The jade library following semver, so this should be a safe change.
