### PR TITLE
bump dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,6 @@ env:
   - JADE=jade@~1.7
   - JADE=jade@~1.8
   - JADE=jade@~1.9
+  - JADE=jade@~1.10
+  - JADE=jade@~1.11
 before_script: npm install $JADE # install a specific version of jade

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "author": "Blaine Bublitz <blaine@iceddev.com>",
   "dependencies": {
     "gulp-util": "^3.0.2",
-    "jade": "1.1 - 1.9",
-    "through2": "^0.6.3"
+    "jade": "1.1 - 1.11",
+    "through2": "^2.0.0"
   },
   "files": [
     "index.js",
@@ -28,7 +28,7 @@
   "license": "MIT",
   "devDependencies": {
     "gulp": "^3.8.10",
-    "tap": "^0.5.0",
+    "tap": "^1.3.1",
     "gulp-jshint": "^1.9.0"
   }
 }


### PR DESCRIPTION
[Jade](http://jade-lang.com/) v1.11.0 has been released. https://github.com/jadejs/jade/blob/master/History.md

I've looked the changelog through and there seems to be no breaking changes related to this plugin.
