### PR TITLE
External template render function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,25 +1,14 @@
 'use strict';
 
 const through = require('through2');
-const defaultJade = require('jade');
 const ext = require('gulp-util').replaceExtension;
 const PluginError = require('gulp-util').PluginError;
-const path = require('path');
+const defaultJade = require('jade');
 
-
-function setPathName(_path, name) {
-  var parsed = path.parse(_path);
-  parsed.base = name;
-  return path.format( parsed );
-}
-function getPathName(_path) {
-  return path.parse(_path).base;
-}
 
 module.exports = function (options) {
   options = options || {};
   var jade = options.jade || defaultJade;
-  var pages = options.pages || {};
 
   return through.obj(function (file, enc, cb) {
     if (file.isNull()) {
@@ -55,26 +44,14 @@ module.exports = function (options) {
   }
 
   function compile(stream, file, data) {
-    var _pages = pages[getPathName(file.path)];
     var tpl = jade.compile(String(file.contents), options);
+    var render = options.render || defaultRender;
+    render.call(stream, tpl, data, file);
+  }
 
-    if (_pages === undefined) {
-      compileTemplate(tpl, data, file);
-    } else {
-      _pages.forEach((page, i) => {
-        var pageFile = file.clone();
-        pageFile.path = setPathName(pageFile.path, page);
-        compileTemplate(tpl, data, pageFile, i);
-      });
-    }
-
-    function compileTemplate(tpl, data, file, pageNum) {
-      data._file = file;
-      data._pageNum = pageNum;
-      file.contents = new Buffer(tpl(data));
-      stream.push(file);
-    }
-
+  function defaultRender(tpl, data, file) {
+    file.contents = new Buffer(tpl(data));
+    this.push(file);
   }
 
 };

--- a/index.js
+++ b/index.js
@@ -46,12 +46,12 @@ module.exports = function (options) {
     function compile(file, data) {
         var template = jade.compile(String(file.contents), options);
         var render = options.render || defaultRender;
-        render.call(this, file, template, data);
+        render.call(this, template, data, file);
     }
 
 }
 
-function defaultRender(file, template, data) {
+function defaultRender(template, data, file) {
     file.contents = new Buffer(template(data));
     this.push(file);
 }

--- a/index.js
+++ b/index.js
@@ -7,51 +7,51 @@ const defaultJade = require('jade');
 
 
 module.exports = function (options) {
-  options = options || {};
-  var jade = options.jade || defaultJade;
+    options = options || {};
+    var jade = options.jade || defaultJade;
 
-  return through.obj(function (file, enc, cb) {
-    if (file.isNull()) {
-      return cb(null, file);
-    }
-    if (file.isStream()) {
-      return cb(new PluginError('gulp-jade', 'Streaming not supported'));
-    }
-
-    if (file.isBuffer()) {
-      options.filename = file.path;
-      file.path = ext(file.path, options.client ? '.js' : '.html');
-      var data = file.data || options.locals || options.data;
-
-      try {
-        if (options.client) {
-          compileClient(this, file);
-        } else {
-          compile(this, file, data);
+    return through.obj(function (file, enc, cb) {
+        if (file.isNull()) {
+            return cb(null, file);
         }
-      } catch (e) {
-        return cb(new PluginError('gulp-jade', e));
-      }
+        if (file.isStream()) {
+            return cb(new PluginError('gulp-jade', 'Streaming not supported'));
+        }
 
-      cb();
+        if (file.isBuffer()) {
+            options.filename = file.path;
+            file.path = ext(file.path, options.client ? '.js' : '.html');
+
+            try {
+                if (options.client) {
+                    compileClient.call(this, file);
+                } else {
+                    var data = file.data || options.locals || options.data;
+                    compile.call(this, file, data);
+                }
+            } catch (e) {
+                return cb(new PluginError('gulp-jade', e));
+            }
+
+            cb();
+        }
+    });
+
+    function compileClient(file) {
+        var template = jade.compileClient(String(file.contents), options);
+        file.contents = new Buffer(template);
+        this.push(file);
     }
-  });
 
-  function compileClient(stream, file) {
-    var compiled = jade.compileClient(String(file.contents), options);
-    file.contents = new Buffer(compiled);
-    stream.push( file );
-  }
+    function compile(file, data) {
+        var template = jade.compile(String(file.contents), options);
+        var render = options.render || defaultRender;
+        render.call(this, file, template, data);
+    }
 
-  function compile(stream, file, data) {
-    var tpl = jade.compile(String(file.contents), options);
-    var render = options.render || defaultRender;
-    render.call(stream, tpl, data, file);
-  }
+}
 
-  function defaultRender(tpl, data, file) {
-    file.contents = new Buffer(tpl(data));
+function defaultRender(file, template, data) {
+    file.contents = new Buffer(template(data));
     this.push(file);
-  }
-
-};
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "dependencies": {
     "gulp-util": "^3.0.2",
     "jade": "1.1 - 1.11",
-    "through2": "^2.0.0"
+    "through2": "^2.0.0",
+    "path" : "^0.12.7",
+    "rename": "^1.0.3"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
In some cases you need to produce a few html files from one template. 
For this is very convenient to pass into the gulp-jade a function which override template render behavior.
For example: 

``` js
function customRender(template, data, file) {
    data.lang = langs.en;
    file.path = ... // rename
    file.contents = new Buffer(template(data));
    this.push(file);

    data.lang = langs.ru;
    file = file.clone();
    file.path = ... // rename
    file.contents = new Buffer(template(data));
    this.push(file);
}
```

Or see my more complex example:
https://bitbucket.org/dddenisss/static-blog-demo/src/98f72b52882a3dc0f1109774430d453e6ecdbde7/gulpfile.js/tasks/jade-compiler.js?at=default&fileviewer=file-view-default
https://bitbucket.org/dddenisss/static-blog-demo/src/98f72b52882a3dc0f1109774430d453e6ecdbde7/gulpfile.js/misc/jade-render.js?at=default&fileviewer=file-view-default
