### PR TITLE
Use `object-assign` instead of `util._extend`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var extend = require('util')._extend;
+var objectAssign = require('object-assign');
 var through = require('through2');
 var defaultPug = require('pug');
 var ext = require('gulp-util').replaceExtension;
 var PluginError = require('gulp-util').PluginError;
 
 module.exports = function gulpPug(options) {
-  var opts = extend({}, options);
+  var opts = objectAssign({}, options);
   var pug = opts.pug || opts.jade || defaultPug;
 
   return through.obj(function compilePug(file, enc, cb) {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "repository": "https://github.com/jamen/gulp-pug.git",
   "dependencies": {
     "gulp-util": "^3.0.2",
+    "object-assign": "^4.1.0",
     "pug": "^2.0.0-alpha6",
     "through2": "^2.0.0"
   },


### PR DESCRIPTION
See https://nodejs.org/docs/latest/api/util.html#util_util_extend_obj

> `_extend` was never intended to be used outside of internal NodeJS modules. The community found and used it anyway.
> 
> It is deprecated and should not be used in new code. JavaScript comes with very similar built-in functionality through `Object.assign`.
