### PR TITLE
Merge stream object data with options data

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ gulp.task('views', function buildHTML() {
 ## API
 ### `pug([opts])`
  - `opts` (`Object`): Any options from [Pug's API][api] in addition to `pug`'s own options.
- - `opts.locals` (`Object`): Locals to compile the Pug with.
+ - `opts.locals` (`Object`): Locals to compile the Pug with. You can also provide locals through the `data` field of the file object, e.g. with [`gulp-data`][gulp-data]. They will be merged with `opts.locals`.
+ - `opts.data` (`Object`): Same as `opts.locals`.
  - `opts.client` (`Boolean`): Compile Pug to JavaScript code.
  - `opts.pug`: A custom instance of Pug for `gulp-pug` to use.
 

--- a/index.js
+++ b/index.js
@@ -13,8 +13,9 @@ module.exports = function gulpPug(options) {
   return through.obj(function compilePug(file, enc, cb) {
     opts.filename = file.path;
 
+    opts.data = objectAssign(opts.data || {}, opts.locals || {});
     if (file.data) {
-      opts.data = file.data;
+      objectAssign(opts.data, file.data);
     }
 
     file.path = ext(file.path, opts.client ? '.js' : '.html');
@@ -30,7 +31,7 @@ module.exports = function gulpPug(options) {
         if (opts.client) {
           compiled = pug.compileClient(contents, opts);
         } else {
-          compiled = pug.compile(contents, opts)(opts.locals || opts.data);
+          compiled = pug.compile(contents, opts)(opts.data);
         }
         file.contents = new Buffer(compiled);
       } catch (e) {

--- a/test/fixtures/helloworld.pug
+++ b/test/fixtures/helloworld.pug
@@ -1,2 +1,3 @@
 h1 Hello, tester!
 h2= title
+h3= foo || 'foo'

--- a/test/test.js
+++ b/test/test.js
@@ -90,6 +90,39 @@ test('should compile my pug files into HTML with data property', function(t) {
     }));
 });
 
+test('should compile my pug files into HTML with data from options and data' +
+  ' property', function(t) {
+  gulp.src(filename)
+    .pipe(setData())
+    .pipe(task({
+      data: {
+        foo: 'bar'
+      }
+    }))
+    .pipe(expectStream(t, {
+      data: {
+        title: 'Greetings!',
+        foo: 'bar'
+      }
+    }));
+});
+
+test('should overwrite data option fields with data property fields when' +
+  'compiling my pug files to HTML', function(t) {
+  gulp.src(filename)
+    .pipe(setData())
+    .pipe(task({
+      data: {
+        title: 'Yellow Curled'
+      }
+    }))
+    .pipe(expectStream(t, {
+      data: {
+        title: 'Greetings!'
+      }
+    }));
+});
+
 test('should compile my pug files into JS', function(t) {
   gulp.src(filename)
     .pipe(task({


### PR DESCRIPTION
Fixes #141 

Allows to combine data from the stream (like from `gulp-data` or `gulp-front-matter`) with data provided in the options.

Adds documentation for the feature to read data from stream objects.
