### PR TITLE
Fix bug of data property fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,14 +10,12 @@ module.exports = function gulpPug(options) {
   var opts = objectAssign({}, options);
   var pug = opts.pug || opts.jade || defaultPug;
 
+  opts.data = objectAssign(opts.data || {}, opts.locals || {});
+
   return through.obj(function compilePug(file, enc, cb) {
+    var data = objectAssign({}, opts.data, file.data || {});
+
     opts.filename = file.path;
-
-    opts.data = objectAssign(opts.data || {}, opts.locals || {});
-    if (file.data) {
-      objectAssign(opts.data, file.data);
-    }
-
     file.path = ext(file.path, opts.client ? '.js' : '.html');
 
     if (file.isStream()) {
@@ -31,7 +29,7 @@ module.exports = function gulpPug(options) {
         if (opts.client) {
           compiled = pug.compileClient(contents, opts);
         } else {
-          compiled = pug.compile(contents, opts)(opts.data);
+          compiled = pug.compile(contents, opts)(data);
         }
         file.contents = new Buffer(compiled);
       } catch (e) {

--- a/test/fixtures/helloworld2.pug
+++ b/test/fixtures/helloworld2.pug
@@ -1,0 +1,3 @@
+h1 Hello, tester!
+h2= title
+h3= foo || 'foo'


### PR DESCRIPTION
Inheritance role of `options.data` in the plug-in was bad.

I tried those.

``` js
var path = require('path');
var gulp = require('gulp');
var data = require('gulp-data');
var pug = require('gulp-pug');

var templateVariables = {
  page1: {
    title: 'Page 1',
    description: 'this is page 1'
  },
  page2: {
    description: 'this is page 2'
  }
};

gulp.task('template', function () {
  return gulp.src([
    'src/page1.pug',
    'src/page2.pug'
  ])
    .pipe(data(function (file) {
      const type = path.basename(file.path, '.pug');
      return templateVariables[type];
    }))
    .pipe(pug())
    .pipe(gulp.dest('dist'));
});
```

`src/page1.pug`

``` jade
if title
  h1= title
else
  h1 This page has no title.

p= description
```

`src/page2.pug`

``` jade
if title
  h1= title
else
  h1 This page has no title.

p= description
```

Then, result was against expectation.

Compiled:

`dist/page1.html`

``` html
<h1>Page 1</h1>
<p>this is page 1</p>
```

`dist/page2.html`

``` html
<h1>Page 1</h1>
<p>this is page 2</p>
```

I correct this by the PR.
