### PR TITLE
feature: new verbose option prints filenames as they are compiled

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ gulp.task('views', function buildHTML() {
  - `opts.data` (`Object`): Same as `opts.locals`.
  - `opts.client` (`Boolean`): Compile Pug to JavaScript code.
  - `opts.pug`: A custom instance of Pug for `gulp-pug` to use.
-
+ - `opts.verbose`: display name of file from stream that is being compiled.
+ 
 To change `opts.filename` use [`gulp-rename`][gulp-rename] before `gulp-pug`.
 
 Returns a stream that compiles Vinyl files as Pug.

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var through = require('through2');
 var defaultPug = require('pug');
 var ext = require('gulp-util').replaceExtension;
 var PluginError = require('gulp-util').PluginError;
+var log = require('gulp-util').log;
 
 module.exports = function gulpPug(options) {
   var opts = objectAssign({}, options);
@@ -26,6 +27,9 @@ module.exports = function gulpPug(options) {
       try {
         var compiled;
         var contents = String(file.contents);
+        if (opts.verbose === true) {
+          log('compiling file', file.path);
+        }
         if (opts.client) {
           compiled = pug.compileClient(contents, opts);
         } else {


### PR DESCRIPTION
Adds a new option that only gulp-pug recognizes: options.verbose (boolean) which displays file path being passed into the compiler.   

Useful for a lot of templates that each take about 5-8 seconds to compile.