### PR TITLE
Added process name/namespace option for compiling to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ gulp.task('views', function buildHTML() {
  - `opts.client` (`Boolean`): Compile Pug to JavaScript code.
  - `opts.pug`: A custom instance of Pug for `gulp-pug` to use.
  - `opts.verbose`: display name of file from stream that is being compiled.
- 
+ - `opts.namespace`: sets a namespace that's used for accessing the templates on client
+ - `opts.processname`: a function that takes the filename for the template and creates a unique function name to access the template when compiling to the client (the template function will be on the namespace defined with `opts.namespace`)
+
 To change `opts.filename` use [`gulp-rename`][gulp-rename] before `gulp-pug`.
 
 Returns a stream that compiles Vinyl files as Pug.

--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ var log = require('gulp-util').log;
 
 // A function to make the namespace client templates are compiled to
 function getNamespaceDeclaration(ns) {
-  const output = [];
-  let curPath = 'this';
+  var output = [];
+  var curPath = 'this';
 
   if (ns !== 'this') {
     var nsParts = ns.split('.');
@@ -41,7 +41,7 @@ module.exports = function gulpPug(options) {
 
   var processName = opts.processName || defaultProcessName;
 
-  let nsInfo;
+  var nsInfo;
   if (opts.namespace) {
     nsInfo = getNamespaceDeclaration(opts.namespace);
   }
@@ -61,8 +61,8 @@ module.exports = function gulpPug(options) {
         var compiled;
         var contents = String(file.contents);
 
-        let localFilePath = file.path.replace(process.cwd() + '/', '');
-        let filename = processName(localFilePath);
+        var localFilePath = file.path.replace(process.cwd() + '/', '');
+        var filename = processName(localFilePath);
 
         if (opts.verbose === true) {
           log('compiling file', file.path);

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ module.exports = function gulpPug(options) {
 
           if (opts.namespace) {
             compiled = nsInfo.namespace + '[' + JSON.stringify(filename) +
-              '] = ' + compiled + ']';
+              '] = ' + compiled;
           }
         } else {
           compiled = pug.compile(contents, opts)(data);

--- a/index.js
+++ b/index.js
@@ -8,18 +8,18 @@ var PluginError = require('gulp-util').PluginError;
 var log = require('gulp-util').log;
 
 // A function to make the namespace client templates are compiled to
-const getNamespaceDeclaration = (ns) => {
+function getNamespaceDeclaration(ns) {
   const output = [];
   let curPath = 'this';
 
   if (ns !== 'this') {
     var nsParts = ns.split('.');
-    nsParts.forEach((curPart) => {
+    nsParts.forEach(function(curPart) {
       if (curPart !== 'this') {
         curPath += '[' + JSON.stringify(curPart) + ']';
         output.push(curPath + ' = ' + curPath + ' || {};');
       }
-    })
+    });
   }
 
   return {
@@ -39,11 +39,11 @@ module.exports = function gulpPug(options) {
     return name.replace('.pug', '');
   };
 
-  var processName = options.processName || defaultProcessName;
+  var processName = opts.processName || defaultProcessName;
 
   let nsInfo;
-  if (options.namespace) {
-    nsInfo = getNamespaceDeclaration(options.namespace)
+  if (opts.namespace) {
+    nsInfo = getNamespaceDeclaration(opts.namespace);
   }
 
   return through.obj(function compilePug(file, enc, cb) {
@@ -70,8 +70,9 @@ module.exports = function gulpPug(options) {
         if (opts.client) {
           compiled = pug.compileClient(contents, opts);
 
-          if (options.namespace) {
-            compiled = nsInfo.namespace + '['+JSON.stringify(filename)+'] = '+ compiled + ']';
+          if (opts.namespace) {
+            compiled = nsInfo.namespace + '[' + JSON.stringify(filename) +
+              '] = ' + compiled + ']';
           }
         } else {
           compiled = pug.compile(contents, opts)(data);


### PR DESCRIPTION
Added 2 options for compiling to client JS with gulp-pug, namespace and processName. The namespace option creates a namespace so that all templates are compiled into the same namespace and can be easily found in the frontend code (as opposed to having all the templates being named 'template'). This change brings the processName option in line with grunt-contrib-pug (apart from a few details allowing this behaviour to only show up when the namespace option is set)