### PR TITLE
Update supported Node versions to LTS and stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 sudo: false
 language: node_js
 node_js:
-  - "6"
-  - "5"
-  - "4"
-  - "0.12"
-  - "0.11"
-  - "0.10"
+  # `gulp-pug` supports the active LTS and current versions of Node
+  # See https://github.com/nodejs/Release
+  - "lts/argon" # EOL: 2018-04-30
+  - "lts/boron" # EOL: April 2019
+  - "lts/carbon" # EOL: December 2019
+  - "stable"
 
 env:
   - PUG=pug@2.0.0-alpha6

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">= 0.10"
+    "node": ">= 4.0.0"
   },
   "scripts": {
     "test": "gulp eslint && tap ./test"


### PR DESCRIPTION
Update Travis CI and `package.json` to test the library against Node
stable and require at least Node LTS.
This is technically a breaking change, but we are only dropping
official support for unmaintained Node versions.

Closes gulp-community/gulp-pug#169