### PR TITLE
Fix invalid import in type definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next
+
+- **Patch**: Fix Typescript type definitions.
+
 # v4.0.0 (2018-04-08)
 
 - **Breaking change**: Update required Node version from `0.10` to `4.0.0`. (#171)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,4 @@
-import Transform from "stream";
-
+import { Transform } from "stream";
 import { Options as PugOptions } from "pug";
 
 /**


### PR DESCRIPTION
The type definitions are importing `default` instead of `Transform` from the `"stream"` module.