### PR TITLE
Release v4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# Next
+# v4.0.1 (2018-04-08)
 
-- **Patch**: Fix Typescript type definitions.
-- **Internal**: Drop dependency on `object-assign`.
-- **Internal**: Use `eslint` directly (without `gulp`).
+- **Patch**: Fix Typescript type definitions. (#179)
+- **Internal**: Drop dependency on `object-assign`. (#177)
+- **Internal**: Use `eslint` directly (without `gulp`). (#180)
 
 # v4.0.0 (2018-04-08)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-pug",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-pug",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Gulp plugin for compiling Pug templates",
   "keywords": [
     "jade",


### PR DESCRIPTION
- **Patch**: Fix Typescript type definitions. (#179)
- **Internal**: Drop dependency on `object-assign`. (#177)
- **Internal**: Use `eslint` directly (without `gulp`). (#180)