### PR TITLE
Added a plugin to the 'Also See' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Returns a stream that compiles Vinyl files as Pug.
  - [`gulp-data`][gulp-data]: Using locals in your Pug templates easier.
  - [`gulp-rename`][gulp-rename]: Change `opts.filename` passed into Pug.
  - [`gulp-wrap-amd`][gulp-wrap-amd]: Wrap your Pug in an AMD wrapper.
+ - [`gulp-frontmatter-wrangler`][gulp-frontmatter-wrangler]: Useful if you need YAML frontmatter at the top of your Pug file.
 
 ## Thanks
 
@@ -53,5 +54,6 @@ Returns a stream that compiles Vinyl files as Pug.
 [gulp-data]: https://npmjs.com/gulp-data
 [gulp-rename]: https://npmjs.com/gulp-rename
 [gulp-wrap-amd]: https://github.com/phated/gulp-wrap-amd
+[gulp-frontmatter-wrangler]: https://github.com/DougBeney/gulp-frontmatter-wrangler
 [phated]: https://github.com/phated
 [license]: LICENSE


### PR DESCRIPTION
Pug throws errors if you have YAML frontmatter at the top of your file. To get around this without hacking with pipe characters, I created a plugin that will let you temporarily pull the frontmatter out of your file, compile it with Pug, and then put it back into the compiled HTML.