### PR TITLE
Put filename of pug file to process into err object if we catch an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ module.exports = function gulpPug(options) {
         }
         file.contents = new Buffer(compiled);
       } catch (e) {
+        e.filename = opts.filename;
         return cb(new PluginError('gulp-pug', e));
       }
     }

--- a/test/error.js
+++ b/test/error.js
@@ -13,6 +13,7 @@ test('should emit errors of pug correctly', function(t) {
     .pipe(task()
       .on('error', function(err) {
         t.ok(err);
+        t.equal(err.filename, __dirname + '/fixtures/pug-error.pug');
         t.ok(err instanceof Error);
         t.end();
       }));


### PR DESCRIPTION
during pug.compile*
Fixes https://github.com/gulp-community/gulp-pug/issues/188