### PR TITLE
feat: Add streaming support using vinyl-contents

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = function gulpPug(options) {
         } else {
           compiled = pug.compile(contents, opts)(data);
         }
-        file.contents = new Buffer(compiled);
+        file.contents = Buffer.from(compiled);
       } catch (err) {
         return cb(new PluginError('gulp-pug', err));
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "plugin-error": "^1.0.1",
     "pug": "^2.0.3",
     "replace-ext": "^1.0.0",
-    "through2": "^3.0.1"
+    "through2": "^3.0.1",
+    "vinyl-contents": "^1.0.0"
   },
   "devDependencies": {
     "@types/node": "^12.0.0",

--- a/test/stream.js
+++ b/test/stream.js
@@ -14,15 +14,16 @@ const base = path.join(cwd, 'fixtures');
 const filePath = path.join(base, 'helloworld.pug');
 const fileContents = fs.readFileSync(filePath);
 
-const file = new Vinyl({
-  path: filePath,
-  base: base,
-  cwd: cwd,
-  contents: fs.createReadStream(filePath),
-});
 
 describe('stream', function() {
   it('should handle streaming contents', function(done) {
+    const file = new Vinyl({
+      path: filePath,
+      base: base,
+      cwd: cwd,
+      contents: fs.createReadStream(filePath),
+    });
+
     function assert(files) {
       var expected = pug.compile(fileContents)();
       expect(files[0]).not.toBeUndefined();
@@ -34,5 +35,25 @@ describe('stream', function() {
       plugin(),
       concat(assert),
     ], done);
+  });
+
+  it('bubbles errors if the stream errors', function(done) {
+    const file = new Vinyl({
+      path: filePath,
+      base: base,
+      cwd: cwd,
+      contents: from([new Error("Boom")])
+    });
+
+    function assert(err) {
+      expect(err).toBeDefined();
+      done();
+    }
+
+    pipe([
+      from.obj([file]),
+      plugin(),
+      concat(),
+    ], assert);
   });
 });

--- a/test/stream.js
+++ b/test/stream.js
@@ -22,7 +22,7 @@ const file = new Vinyl({
 });
 
 describe('stream', function() {
-  it('should error if contents is a stream', function(done) {
+  it('should handle streaming contents', function(done) {
     function assert(files) {
       var expected = pug.compile(fileContents)();
       expect(files[0]).not.toBeUndefined();

--- a/test/test.js
+++ b/test/test.js
@@ -182,4 +182,22 @@ describe('test', function () {
       done
     );
   });
+
+  it('skips over any files without contents', function (done) {
+    const file = getFixture('helloworld.pug');
+    file.contents = null;
+
+    function assert(files) {
+      expect(files.length).toEqual(1);
+      const newFile = files[0];
+      expect(newFile).toBe(file);
+      expect(newFile.contents).toBe(null);
+    }
+
+
+    pipe(
+      [from.obj([file]), task(), concat(assert)],
+      done
+    );
+  });
 });


### PR DESCRIPTION
@demurgos here is a really quick implementation (with only 1 test) of adding streaming support.  Going forward, I think this pattern is going to be the recommended pattern to support streaming in plugins that wrap a module that doesn't support streaming.

I didn't want to try to redo everything since I know you are working on the test updates and I'll have to rebase this when completed.

Closes #198 