### PR TITLE
Cleanup tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
+  "extends": "gulp",
   "parserOptions": {
     "ecmaVersion": 2015
-  },
-  "extends": "gulp"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "pretest": "npm run lint",
-    "test": "mocha test",
+    "test": "mocha --async-only",
     "lint": "eslint index.js \"test/**/*.js\""
   },
   "license": "MIT",

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,13 +1,6 @@
 {
-  "globals": {
-    "describe": true,
-    "it": true
-  },
+  "extends": "gulp/test",
   "parserOptions": {
     "ecmaVersion": 2015
-  },
-  "rules": {
-    "max-len": "off"
-  },
-  "extends": "gulp"
+  }
 }

--- a/test/error.js
+++ b/test/error.js
@@ -8,16 +8,13 @@ const { getFixture } = require('./get-fixture');
 
 describe('error', function() {
   it('should emit errors of pug correctly', function(done) {
-    pipe(
-      [from.obj([getFixture('pug-error.pug')]), task(), concat()],
-      (err) => {
-        try {
-          expect(err).toBeInstanceOf(PluginError);
-          done();
-        } catch (err) {
-          done(err);
-        }
-      }
-    );
+    pipe([
+      from.obj([getFixture('pug-error.pug')]),
+      task(),
+      concat(),
+    ], (err) => {
+      expect(err).toBeInstanceOf(PluginError);
+      done();
+    });
   });
 });

--- a/test/stream.js
+++ b/test/stream.js
@@ -21,16 +21,13 @@ const file = new Vinyl({
 
 describe('stream', function() {
   it('should error if contents is a stream', function(done) {
-    pipe(
-      [from.obj([file]), task(), concat()],
-      (err) => {
-        try {
-          expect(err).toBeInstanceOf(PluginError);
-          done();
-        } catch (err) {
-          done(err);
-        }
-      }
-    );
+    pipe([
+      from.obj([file]),
+      task(),
+      concat(),
+    ], (err) => {
+      expect(err).toBeInstanceOf(PluginError);
+      done();
+    });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -21,12 +21,12 @@ function setData() {
   });
 }
 
-function expectStream(options) {
+function assertStream(options) {
   options = options || {};
   const ext = options.client ? '.js' : '.html';
   const compiler = options.client ? pug.compileClient : pug.compile;
 
-  function assert(file, _enc, cb) {
+  function assert(file) {
     options.filename = file.path.replace(new RegExp(ext + '$'), '.pug');
     const compiled = compiler(fs.readFileSync(options.filename), options);
     const data = Object.assign({}, options.data, options.locals, file.data);
@@ -38,10 +38,9 @@ function expectStream(options) {
     } else {
       expect(path.extname(file.relative)).toStrictEqual('');
     }
-    cb(null, file);
   }
 
-  return through.obj(assert);
+  return concat((files) => files.forEach(assert));
 }
 
 describe('test', function() {
@@ -49,8 +48,7 @@ describe('test', function() {
     pipe([
       from.obj([getFixture('helloworld.pug')]),
       task(),
-      expectStream(),
-      concat(),
+      assertStream(),
     ], done);
   });
 
@@ -64,8 +62,7 @@ describe('test', function() {
     pipe([
       from.obj([getFixture('helloworld.pug')]),
       task(options),
-      expectStream(options),
-      concat(),
+      assertStream(options),
     ], done);
   });
 
@@ -79,8 +76,7 @@ describe('test', function() {
     pipe([
       from.obj([getFixture('helloworld.pug')]),
       task(options),
-      expectStream(options),
-      concat(),
+      assertStream(options),
     ], done);
   });
 
@@ -89,8 +85,7 @@ describe('test', function() {
       from.obj([getFixture('helloworld.pug')]),
       setData(),
       task(),
-      expectStream({ data: { title: 'Greetings' } }),
-      concat(),
+      assertStream({ data: { title: 'Greetings' } }),
     ], done);
   });
 
@@ -99,8 +94,7 @@ describe('test', function() {
       from.obj([getFixture('helloworld.pug')]),
       setData(),
       task({ data: { foo: 'bar' } }),
-      expectStream({ data: { title: 'Greetings', foo: 'bar' } }),
-      concat(),
+      assertStream({ data: { title: 'Greetings', foo: 'bar' } }),
     ], done);
   });
 
@@ -109,8 +103,7 @@ describe('test', function() {
       from.obj([getFixture('helloworld.pug')]),
       setData(),
       task({ data: { title: 'Yellow Curled' } }),
-      expectStream({ data: { title: 'Greetings' } }),
-      concat(),
+      assertStream({ data: { title: 'Greetings' } }),
     ], done);
   });
 
@@ -129,8 +122,7 @@ describe('test', function() {
         cb(null, file);
       }),
       task(),
-      expectStream(),
-      concat(),
+      assertStream(),
     ], done);
   });
 
@@ -140,8 +132,7 @@ describe('test', function() {
     pipe([
       from.obj([getFixture('helloworld.pug')]),
       task(options),
-      expectStream(options),
-      concat(),
+      assertStream(options),
     ], done);
   });
 


### PR DESCRIPTION
@demurgos I just wanted to clean up the tests a bit more.

* Using `extends: "gulp/test"` in the eslintrc allows us to not override any rules
* try/catch isn't needed within the `pipe` callback because it will bubble the errors to the `it` block if the assertion fails - I tested this locally and it works
* The `expectStream` should be the end of the pipeline instead of using another transform stream and then concat - just to simplify the code a bit.