### PR TITLE
Update license to show correctly on github

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,6 @@
 The MIT License (MIT)
 
-Originally based on gulp-jade, copyright Blaine Bublitz
-
-Copyright (c) 2016 Jamen Marzonie <jamenmarz@gmail.com> (http://jamenmarz.com)
+Copyright (c) 2013-2019 Blaine Bublitz <blaine.bublitz@gmail.com>, Jamen Marzonie <jamenmarz@gmail.com>, and Charles Samborski <demurgos@demurgos.net>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
@demurgos I've updated the license as well because it was showing weird on the repo page.  I was the original copyright holder so this should be fine.