### PR TITLE
Finish PR #199 „Accept a function as options.name“

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ exports.views = () => {
 - `opts.locals` (`Object`): Locals to compile the Pug with. You can also provide locals through the `data` field of the file object, e.g. with [`gulp-data`][gulp-data]. They will be merged with `opts.locals`.
 - `opts.data` (`Object`): Same as `opts.locals`.
 - `opts.client` (`Boolean`): Compile Pug to JavaScript code.
+- `opts.name` (`string | ((file: VinylFile) => string)`): The name of your client side template function, when `opts.client` is set to `True`. When passed as a function, takes current Pug file as an argument.
 - `opts.pug`: A custom instance of Pug for `gulp-pug` to use.
 - `opts.verbose`: display name of file from stream that is being compiled.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,12 @@ declare namespace GulpPug {
     client?: boolean;
 
     /**
+     * If passed as a string, used as the name of your client side template function. If passed as a function, 
+     * it is called with a pug template file as an argument, to obtain a name of client side template function.
+     */
+    name?: string | ((file: VinylFile) => string);
+
+    /**
      * A custom instance of Pug for `gulp-pug` to use.
      */
     pug?: any;

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const vinylContents = require('vinyl-contents');
 
 module.exports = function gulpPug(options) {
   const opts = Object.assign({}, options);
+  const namefunc = typeof opts.name === 'function' ? opts.name : undefined;
   const pug = opts.pug || opts.jade || defaultPug;
 
   opts.data = Object.assign(opts.data || {}, opts.locals || {});
@@ -37,8 +38,8 @@ module.exports = function gulpPug(options) {
           log('compiling file', file.path);
         }
         if (opts.client) {
-          if (typeof options.name === 'function') {
-            opts.name = options.name(file);
+          if (typeof namefunc === 'function') {
+            opts.name = namefunc(file);
           }
           compiled = pug.compileClient(contents, opts);
         } else {

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ const vinylContents = require('vinyl-contents');
 
 module.exports = function gulpPug(options) {
   const opts = Object.assign({}, options);
-  const namefunc = opts.name;
   const pug = opts.pug || opts.jade || defaultPug;
 
   opts.data = Object.assign(opts.data || {}, opts.locals || {});
@@ -18,9 +17,6 @@ module.exports = function gulpPug(options) {
     const data = Object.assign({}, opts.data, file.data || {});
 
     opts.filename = file.path;
-    if (typeof namefunc === 'function') {
-      opts.name = namefunc(file);
-    }
     file.path = ext(file.path, opts.client ? '.js' : '.html');
 
     vinylContents(file, function onContents(err, contents) {
@@ -41,6 +37,9 @@ module.exports = function gulpPug(options) {
           log('compiling file', file.path);
         }
         if (opts.client) {
+          if (typeof options.name === 'function') {
+            opts.name = options.name(file);
+          }
           compiled = pug.compileClient(contents, opts);
         } else {
           compiled = pug.compile(contents, opts)(data);

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const vinylContents = require('vinyl-contents');
 
 module.exports = function gulpPug(options) {
   const opts = Object.assign({}, options);
+  const namefunc = opts.name;
   const pug = opts.pug || opts.jade || defaultPug;
 
   opts.data = Object.assign(opts.data || {}, opts.locals || {});
@@ -17,6 +18,9 @@ module.exports = function gulpPug(options) {
     const data = Object.assign({}, opts.data, file.data || {});
 
     opts.filename = file.path;
+    if (typeof namefunc === 'function') {
+      opts.name = namefunc(file);
+    }
     file.path = ext(file.path, opts.client ? '.js' : '.html');
 
     vinylContents(file, function onContents(err, contents) {

--- a/test/test.js
+++ b/test/test.js
@@ -153,6 +153,32 @@ describe('test', function () {
     );
   });
 
+  it('should name the compiled JS function using name option', function (done) {
+    function name(file) {
+      if (!file || !file.name) {
+        return 'template';
+      }
+      return '__' + path.basename(file.path, '.pug') + '__';
+    }
+
+    const templateFilename = 'helloworld.pug';
+
+    function assert(files) {
+      expect(files.length).toEqual(1);
+      const newFileContent = files[0].contents.toString();
+      expect(newFileContent).toContain("function " + name(templateFilename) + "(");
+    }
+
+    pipe(
+      [
+        from.obj([getFixture(templateFilename)]),
+        task({ client: true, name }),
+        concat(assert),
+      ],
+      done
+    );
+  });
+
   it('should always return contents as buf with client = true', function (done) {
     function assert(files) {
       expect(files.length).toEqual(1);


### PR DESCRIPTION
**Context.** Two years ago @wiggisser created a PR https://github.com/gulp-community/gulp-pug/pull/199 that allowed `options.name` argument to accept functions. It implemented all the functionality, but wasn't rebased and lacked some other things. Citing the discussion: 
> [...] add a changelog entry, update the type definitions, documentation and rebase on top of https://github.com/gulp-community/gulp-pug/pull/201.


**PR description.** This PR includes original @wiggisser commits and also updates type definitions, documentation, and rebases on top of latest commit (8c9ecc12d8ae63613b2067c5ab006dfd9132ef45). The rebase is simply switching test framework from Tape to Mocha. The only thing left now is to add a changelog entry.

**Next step.** Changelog format requires to provide a link to the latest commit and a link to the version comparison via tags. As I'm not able to create tags in this repo, and commit won't be available untill the PR is merged, I can't update the changelog. @phated could you help me with that?